### PR TITLE
fix: change --targets filter from prefix to substring matching

### DIFF
--- a/specs/001-list-top-functions/spec.md
+++ b/specs/001-list-top-functions/spec.md
@@ -56,7 +56,7 @@ A developer wants to control how many functions appear in the output, either exp
 
 ### User Story 4 - Filter by Function Names (Priority: P3)
 
-A developer wants to see statistics only for specific functions they are interested in, using full names or prefixes.
+A developer wants to see statistics only for specific functions they are interested in, using substring patterns (e.g., method names within class::method symbols).
 
 **Why this priority**: Targeted analysis of known functions speeds up performance investigation.
 
@@ -65,9 +65,9 @@ A developer wants to see statistics only for specific functions they are interes
 **Acceptance Scenarios**:
 
 1. **Given** a valid perf report file, **When** running `pperf top --targets "DCT4DBlock::DCT4DBlock" report.txt`, **Then** only exact matches are displayed
-2. **Given** a valid perf report file, **When** running `pperf top --targets DCT4D report.txt`, **Then** all functions with names starting with "DCT4D" are displayed
-3. **Given** multiple targets, **When** running `pperf top --targets DCT4D Hierarchical report.txt`, **Then** functions matching any target prefix are displayed
-4. **Given** a prefix matching multiple function signatures, **When** filtering, **Then** each matching signature is shown with a distinguishing suffix (e.g., `#1`, `#2`)
+2. **Given** a valid perf report file, **When** running `pperf top --targets get_mSubband report.txt`, **Then** all functions containing "get_mSubband" anywhere in their name are displayed (e.g., `Hierarchical4DEncoder::get_mSubbandLF_significance`)
+3. **Given** multiple targets, **When** running `pperf top --targets DCT4D get_mSubband report.txt`, **Then** functions matching any target substring are displayed
+4. **Given** a pattern matching multiple function signatures, **When** filtering, **Then** each matching signature is shown with a distinguishing suffix (e.g., `#1`, `#2`)
 5. **Given** a target with no matches, **When** running `pperf top --targets nonexistent report.txt`, **Then** output shows "No matching functions found"
 
 ---
@@ -95,9 +95,9 @@ A developer wants to see statistics only for specific functions they are interes
 - **FR-004**: System MUST support `--self` flag to sort by Self% instead
 - **FR-005**: System MUST default to displaying 10 results
 - **FR-006**: System MUST support `-n <number>` flag to change result count (positive integers only)
-- **FR-007**: System MUST support `--targets <name>...` to filter functions by name prefix
-- **FR-008**: System MUST match targets against function names using prefix matching
-- **FR-009**: System MUST display all matches when a prefix matches multiple signatures
+- **FR-007**: System MUST support `--targets <name>...` to filter functions by substring pattern
+- **FR-008**: System MUST match targets against function names using substring matching (pattern can appear anywhere in symbol name)
+- **FR-009**: System MUST display all matches when a pattern matches multiple signatures
 - **FR-010**: System MUST distinguish functions with identical base names by appending a numeric suffix (e.g., `#1`, `#2`)
 - **FR-011**: System MUST output results in a tabular format similar to `ls -l` (aligned columns, no borders)
 - **FR-012**: System MUST read perf report from a file path argument
@@ -107,7 +107,7 @@ A developer wants to see statistics only for specific functions they are interes
 
 - **PerfEntry**: A single function's profiling data containing Children%, Self%, Command, Shared Object, and Symbol
 - **PerfReport**: A collection of PerfEntries parsed from a perf report file
-- **FunctionFilter**: A mechanism to match function names by exact match or prefix
+- **FunctionFilter**: A mechanism to match function names by substring pattern
 
 ## Success Criteria *(mandatory)*
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -7,13 +7,13 @@ pub fn filter_entries(entries: &[PerfEntry], targets: &[String]) -> Vec<PerfEntr
 
     entries
         .iter()
-        .filter(|entry| targets.iter().any(|t| matches_prefix(&entry.symbol, t)))
+        .filter(|entry| targets.iter().any(|t| matches_pattern(&entry.symbol, t)))
         .cloned()
         .collect()
 }
 
-pub fn matches_prefix(symbol: &str, pattern: &str) -> bool {
-    symbol == pattern || symbol.starts_with(pattern)
+pub fn matches_pattern(symbol: &str, pattern: &str) -> bool {
+    symbol.contains(pattern)
 }
 
 #[cfg(test)]
@@ -21,20 +21,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_matches_prefix_exact() {
-        assert!(matches_prefix("DCT4DBlock", "DCT4DBlock"));
+    fn test_matches_pattern_exact() {
+        assert!(matches_pattern("DCT4DBlock", "DCT4DBlock"));
     }
 
     #[test]
-    fn test_matches_prefix_prefix_match() {
-        assert!(matches_prefix("DCT4DBlock::transform", "DCT4D"));
-        assert!(matches_prefix("std::inner_product", "std::"));
+    fn test_matches_pattern_prefix() {
+        assert!(matches_pattern("DCT4DBlock::transform", "DCT4D"));
+        assert!(matches_pattern("std::inner_product", "std::"));
     }
 
     #[test]
-    fn test_matches_prefix_no_match() {
-        assert!(!matches_prefix("Block4D", "DCT4D"));
-        assert!(!matches_prefix("transform", "DCT4D"));
+    fn test_matches_pattern_substring() {
+        // Key feature: match anywhere in the symbol
+        assert!(matches_pattern(
+            "Hierarchical4DEncoder::get_mSubband",
+            "get_mSubband"
+        ));
+        assert!(matches_pattern(
+            "std::inner_product<double>",
+            "inner_product"
+        ));
+        assert!(matches_pattern(
+            "Block4D::get_linear_position",
+            "linear_position"
+        ));
+    }
+
+    #[test]
+    fn test_matches_pattern_no_match() {
+        assert!(!matches_pattern("Block4D", "DCT4D"));
+        assert!(!matches_pattern("transform", "mSubband"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ fn print_help() {
     println!("OPTIONS:");
     println!("    --self, -s           Sort by Self% instead of Children%");
     println!("    -n, --number <N>     Number of functions to display (default: 10)");
-    println!("    --targets, -t <N>... Filter by function name prefixes");
+    println!("    --targets, -t <N>... Filter by function name substrings");
     println!("    --help, -h           Show this help message");
     println!("    --version            Show version information");
 }


### PR DESCRIPTION
Previously, --targets used prefix matching which required knowing the full class name (e.g., `Hierarchical4DEncoder::get_mSubband`). Now uses substring matching so users can filter by method name alone:

  pperf top --targets get_mSubband perf-report.txt

This matches `Hierarchical4DEncoder::get_mSubbandLF_significance` and similar functions where the pattern appears anywhere in the symbol.

- Update matches_prefix() → matches_pattern() using contains()
- Update spec.md to reflect substring matching behavior
- Update CLI help text
- Add test_top_command_targets_substring_match integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)